### PR TITLE
Twig renderer will throw a meaningful error if template name can not be resolved

### DIFF
--- a/src/ZfTwig/Exception.php
+++ b/src/ZfTwig/Exception.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ZfTwig;
+
+/**
+ * ZFTwig exception market interface
+ */
+interface Exception
+{
+}

--- a/src/ZfTwig/Exception/NotFoundException.php
+++ b/src/ZfTwig/Exception/NotFoundException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ZfTwig\Exception;
+use ZfTwig\Exception;
+
+/**
+ * Not found exception
+ */
+class NotFoundException extends \RuntimeException implements Exception
+{
+}

--- a/src/ZfTwig/TwigRenderer.php
+++ b/src/ZfTwig/TwigRenderer.php
@@ -207,6 +207,11 @@ class TwigRenderer implements ZendViewRenderer
         $vars = $this->vars()->getArrayCopy();
 
         $name = $this->resolver($nameOrModel);
+        if(empty($name)) {
+            throw new Exception\NotFoundException(
+                "Can't resolve template '$nameOrModel'."
+            );
+        }
 
         $content = $this->getEnvironment()->render($name, $vars);
         return $this->getFilterChain()->filter($content); // filter output


### PR DESCRIPTION
This is probably better to indicate that resolver problem has occured (like bad template name) and throw an exception since AggregateResolver returns 'false' for such cases (not null) wich passes all checks for if $name=null and results in quite weird exceptions.
