### PR TITLE
Adjustments to work with ZF2 beta4

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,11 +2,11 @@
 
 namespace ZfTwig;
 
-use Zend\Module\Manager,
+use Zend\ModuleManager\ModuleManager,
     Zend\EventManager\StaticEventManager,
-    Zend\Module\Consumer\AutoloaderProvider;
+    Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 
-class Module implements AutoloaderProvider
+class Module implements AutoloaderProviderInterface
 {
 
     public function getAutoloaderConfig()


### PR DESCRIPTION
In beta4 some classes were refactored and therefore the namespaces changed. To allow usage in Zf2 beta 4 There need to be some adjustments to Module.php so the module loads correctly.
